### PR TITLE
Update codesniffer dependency to allow > 2.3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "squizlabs/php_codesniffer": "~1.5.1"
+        "squizlabs/php_codesniffer": "~1.5.1||>=2.3.3"
     },
     "scripts": {
         "post-install-cmd": "ln -s ../../../../../Security vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Security"


### PR DESCRIPTION
This should allow codesniffer version 2 to be used, which stops any conflicts with the 8.x branch of coder. Still allows ~1.5.1 for anyone using projects requiring it.

No reason for 2.3.3 specifically, other than that being the version that we've been using, and we haven't noticed any issues. 