### PR TITLE
Don't recognize object method as filesystem func

### DIFF
--- a/Security/Sniffs/BadFunctions/FilesystemFunctionsSniff.php
+++ b/Security/Sniffs/BadFunctions/FilesystemFunctionsSniff.php
@@ -32,6 +32,11 @@ class FilesystemFunctionsSniff implements Sniff  {
 			if ($tokens[$stackPtr]['content'] == 'symlink') {
 				$phpcsFile->addWarning('Allowing symlink() while open_basedir is used is actually a security risk. Disabled by default in Suhosin >= 0.9.6', $stackPtr, 'WarnSymlink');
 			}
+			
+			if ($tokens[$stackPtr - 1]['code'] == T_OBJECT_OPERATOR) {
+				return;
+			}
+			
             $s = $stackPtr + 1;
 			$opener = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr, null, false, null, true);
 			if (!$opener) {


### PR DESCRIPTION
If you have a class with a method e.g. *delete* this sniff will give a warning when used with dynamic parameter. As long as only global functions must be checked this makes no sense.