### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/Security/Sniffs/Drupal8/Utils.php
+++ b/Security/Sniffs/Drupal8/Utils.php
@@ -11,15 +11,15 @@ class Utils extends Security_Sniffs_Symfony2_Utils {
 	public static function is_token_user_input($t) {
 		if ($t['code'] == T_VARIABLE || $t['code'] == T_STRING) {
 			if (parent::is_token_user_input($t)) {
-				return TRUE;
+				return true;
 			} else {
 				if ($t['content'] == '$form') {
-					return TRUE;
+					return true;
 				} elseif ($t['content'] == 'arg') {
-					return TRUE;
+					return true;
 				}
 			}
-			return FALSE;
+			return false;
 		}
 	}
 


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!