### PR TITLE
Fixed #42: Non-system exec calls incorrectly flagged.

### DIFF
--- a/Security/Sniffs/BadFunctions/SystemExecFunctionsSniff.php
+++ b/Security/Sniffs/BadFunctions/SystemExecFunctionsSniff.php
@@ -30,6 +30,9 @@ class SystemExecFunctionsSniff implements Sniff {
 		$tokens = $phpcsFile->getTokens();
 
 		if (in_array($tokens[$stackPtr]['content'], $utils::getSystemexecFunctions())) {
+            if ($tokens[$stackPtr - 1]['code'] == T_OBJECT_OPERATOR) {
+                return;
+            }
             $opener = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr, null, false, null, true);
 			$closer = $tokens[$opener]['parenthesis_closer'];
             $s = $stackPtr + 1;


### PR DESCRIPTION
Fixes #42 

I see that a very similar issue was previously fixed for another sniff: https://github.com/FloeDesignTechnologies/phpcs-security-audit/pull/20

It seems like this is a pretty common pattern that should be fixed comprehensively somehow. But this PR at least solves it for my use case.