### PR TITLE
Misc/IncludeMismatch: bug fix

### DIFF
--- a/Security/Sniffs/Misc/IncludeMismatchSniff.php
+++ b/Security/Sniffs/Misc/IncludeMismatchSniff.php
@@ -26,7 +26,13 @@ class IncludeMismatchSniff implements Sniff {
 	*/
 	public function process(File $phpcsFile, $stackPtr) {
 		$tokens = $phpcsFile->getTokens();
-		$s = $phpcsFile->findNext(\PHP_CodeSniffer\Util\Tokens::$stringTokens, $stackPtr + 1);
+
+		$end = $phpcsFile->findEndOfStatement($stackPtr);
+		$s   = $phpcsFile->findPrevious(\PHP_CodeSniffer\Util\Tokens::$stringTokens, $end, $stackPtr);
+		if ($s === false) {
+			return;
+		}
+
 		if (preg_match('/\.(\w+)(?:\'|\")$/', $tokens[$s]['content'], $matches)) {
 			$ext = $matches[1];
 			if (!array_key_exists($ext, $phpcsFile->config->extensions)) {

--- a/tests.php
+++ b/tests.php
@@ -42,6 +42,7 @@
 	// Misc
 	$a->withHeader('Access-Control-Allow-Origin', '*');
 	include('abc.xyz');
+	require_once EXTENSION_PATH . '/path/to' . $name . '.php';
 
 	// Easy user input
 	$_GET['a'] = 'xss';


### PR DESCRIPTION
The file name may be build up of several parts. The sniff - until now - would only look at the first text string token for the extension, while the extension will normally be in the _last_ text string token.

This commit changes the sniff to walk back from the end of the statement instead of forward.

Includes unit test.