### PR TITLE
Example rulesets: make the names more specific

### DIFF
--- a/example_base_ruleset.xml
+++ b/example_base_ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="Drupal7">
+<ruleset name="PHPSecurity">
  <description>Rules for standard PHP projects</description>
 
 <!-- Code Reviews Rules -->
@@ -12,7 +12,7 @@
 
 <!-- Global properties -->
 <!-- Please note that not every sniff uses them and they can be overwritten by rule -->
-<!-- Paranoya mode: Will generate more alerts but will miss less vulnerabilites. Good for assisting manual code review. -->
+<!-- Paranoia mode: Will generate more alerts but will miss less vulnerabilites. Good for assisting manual code review. -->
 <config name="ParanoiaMode" value="1"/>
 
 <!-- BadFunctions -->

--- a/example_drupal7_ruleset.xml
+++ b/example_drupal7_ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="Drupal7">
+<ruleset name="Drupal7Security">
  <description>Rules for Drupal 7 projects</description>
 <!-- Code Reviews Rules -->
 <!--
@@ -13,7 +13,7 @@
 <!-- Please note that not every sniff uses them and they can be overwritten by rule -->
 <!-- Framework or CMS used. Must be a class under Security_Sniffs. -->
 <config name="CmsFramework" value="Drupal7"/>
-<!-- Paranoya mode: Will generate more alerts but will miss less vulnerabilites. Good for assisting manual code review. -->
+<!-- Paranoia mode: Will generate more alerts but will miss less vulnerabilites. Good for assisting manual code review. -->
 <config name="ParanoiaMode" value="1"/>
 
 <!-- BadFunctions -->


### PR DESCRIPTION
... to prevent confusion with, for instance, the Drupal code style rulesets.

Includes minor spelling fix.