### PR TITLE
Add initial CI check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,66 @@
+dist: trusty
+
+language: php
+
+## Cache composer and apt downloads.
+cache:
+  apt: true
+  directories:
+    # Cache directory for older Composer versions.
+    - $HOME/.composer/cache/files
+    # Cache directory for more recent Composer versions.
+    - $HOME/.cache/composer/files
+
+php:
+  - 5.4
+  - 7.4
+  - "nightly"
+
+# Define the stages used.
+stages:
+  - name: sniff
+  - name: test
+
+jobs:
+  fast_finish: true
+
+  include:
+    #### SNIFF STAGE ####
+    - stage: sniff
+      php: 7.4
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
+      script:
+        # Validate the composer.json file.
+        # @link https://getcomposer.org/doc/03-cli.md#validate
+        - composer validate --no-check-all --strict
+
+        # Validate the xml files.
+        # @link http://xmlsoft.org/xmllint.html
+        - xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./Security/ruleset.xml
+        - xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./example_base_ruleset.xml
+        - xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./example_drupal7_ruleset.xml
+
+        # Check the code-style consistency of the xml files.
+        - diff -B ./Security/ruleset.xml <(xmllint --format "./Security/ruleset.xml")
+        - diff -B ./example_base_ruleset.xml <(xmllint --format "./example_base_ruleset.xml")
+        - diff -B ./example_drupal7_ruleset.xml <(xmllint --format "./example_drupal7_ruleset.xml")
+
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: "nightly"
+
+before_install:
+  # Speed up build time by disabling Xdebug when its not needed.
+  - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+
+  - export XMLLINT_INDENT="    "
+
+  # --prefer-dist will allow for optimal use of the travis caching ability.
+  - composer install --prefer-dist --no-suggest
+
+script:
+  # Lint PHP files against parse errors.
+  - composer lint

--- a/Security/ruleset.xml
+++ b/Security/ruleset.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Security" namespace="PHPCS_SecurityAudit\Security" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
- <description>Security related coding standard.</description>
+    <description>Security related coding standard.</description>
 </ruleset>

--- a/Security/ruleset.xml
+++ b/Security/ruleset.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
-<ruleset name="Security" namespace="PHPCS_SecurityAudit\Security">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Security" namespace="PHPCS_SecurityAudit\Security" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
  <description>Security related coding standard.</description>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "pheromone/phpcs-security-audit",
-	"type" : "phpcodesniffer-standard",
+    "type" : "phpcodesniffer-standard",
     "description": "phpcs-security-audit is a set of PHP_CodeSniffer rules that finds vulnerabilities and weaknesses related to security in PHP code",
     "license": "GPL-3.0-or-later",
     "authors": [
@@ -13,5 +13,16 @@
         "php": ">=5.4",
         "squizlabs/php_codesniffer": "^3.0.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6"
+    },
+    "require-dev" : {
+        "php-parallel-lint/php-parallel-lint": "^1.0",
+        "php-parallel-lint/php-console-highlighter": "^0.4"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "scripts" : {
+        "lint": [
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+        ]
     }
 }

--- a/example_base_ruleset.xml
+++ b/example_base_ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PHPSecurity">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPSecurity" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
  <description>Rules for standard PHP projects</description>
 
 <!-- Code Reviews Rules -->

--- a/example_base_ruleset.xml
+++ b/example_base_ruleset.xml
@@ -1,53 +1,52 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPSecurity" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
- <description>Rules for standard PHP projects</description>
+    <description>Rules for standard PHP projects</description>
 
-<!-- Code Reviews Rules -->
-<!--
- <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
- <rule ref="PEAR"/>
--->
+    <!-- Code Reviews Rules -->
+    <!--
+    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+    <rule ref="PEAR"/>
+    -->
 
-<!-- Security Code Reviews Rules -->
+    <!-- Security Code Reviews Rules -->
 
-<!-- Global properties -->
-<!-- Please note that not every sniff uses them and they can be overwritten by rule -->
-<!-- Paranoia mode: Will generate more alerts but will miss less vulnerabilites. Good for assisting manual code review. -->
-<config name="ParanoiaMode" value="1"/>
+    <!-- Global properties. -->
+    <!-- Please note that not every sniff uses them and they can be overwritten per rule. -->
+    <!-- Paranoia mode: Will generate more alerts but will miss less vulnerabilites. Good for assisting manual code review. -->
+    <config name="ParanoiaMode" value="1"/>
 
-<!-- BadFunctions -->
-<!-- PHP functions that can lead to security issues -->
-<rule ref="Security.BadFunctions.Asserts"/>
-<rule ref="Security.BadFunctions.Backticks"/>
-<rule ref="Security.BadFunctions.CallbackFunctions"/>
-<rule ref="Security.BadFunctions.CryptoFunctions"/>
-<rule ref="Security.BadFunctions.EasyRFI"/>
-<rule ref="Security.BadFunctions.EasyXSS">
-	<properties>
-		<!-- Comment out to follow global ParanoiaMode -->
-		<property name="forceParanoia" value="1"/>
-	</properties>
-</rule>
-<rule ref="Security.BadFunctions.ErrorHandling"/>
-<rule ref="Security.BadFunctions.FilesystemFunctions"/>
-<rule ref="Security.BadFunctions.FringeFunctions"/>
-<rule ref="Security.BadFunctions.FunctionHandlingFunctions"/>
-<rule ref="Security.BadFunctions.Mysqli"/>
-<rule ref="Security.BadFunctions.NoEvals"/>
-<rule ref="Security.BadFunctions.Phpinfos"/>
-<rule ref="Security.BadFunctions.PregReplace"/>
-<rule ref="Security.BadFunctions.SQLFunctions"/>
-<rule ref="Security.BadFunctions.SystemExecFunctions"/>
+    <!-- BadFunctions -->
+    <!-- PHP functions that can lead to security issues -->
+    <rule ref="Security.BadFunctions.Asserts"/>
+    <rule ref="Security.BadFunctions.Backticks"/>
+    <rule ref="Security.BadFunctions.CallbackFunctions"/>
+    <rule ref="Security.BadFunctions.CryptoFunctions"/>
+    <rule ref="Security.BadFunctions.EasyRFI"/>
+    <rule ref="Security.BadFunctions.EasyXSS">
+        <properties>
+            <!-- Comment out to follow global ParanoiaMode -->
+            <property name="forceParanoia" value="1"/>
+        </properties>
+    </rule>
+    <rule ref="Security.BadFunctions.ErrorHandling"/>
+    <rule ref="Security.BadFunctions.FilesystemFunctions"/>
+    <rule ref="Security.BadFunctions.FringeFunctions"/>
+    <rule ref="Security.BadFunctions.FunctionHandlingFunctions"/>
+    <rule ref="Security.BadFunctions.Mysqli"/>
+    <rule ref="Security.BadFunctions.NoEvals"/>
+    <rule ref="Security.BadFunctions.Phpinfos"/>
+    <rule ref="Security.BadFunctions.PregReplace"/>
+    <rule ref="Security.BadFunctions.SQLFunctions"/>
+    <rule ref="Security.BadFunctions.SystemExecFunctions"/>
 
-<!-- CVE -->
-<!-- Entries from CVE database from vendor PHP and bugs.php.net -->
-<rule ref="Security.CVE.CVE20132110"/>
-<rule ref="Security.CVE.CVE20134113"/>
+    <!-- CVE -->
+    <!-- Entries from CVE database from vendor PHP and bugs.php.net -->
+    <rule ref="Security.CVE.CVE20132110"/>
+    <rule ref="Security.CVE.CVE20134113"/>
 
-<!-- Misc -->
-<rule ref="Security.Misc.BadCorsHeader"/>
-<rule ref="Security.Misc.IncludeMismatch"/>
-<rule ref="Security.Misc.TypeJuggle"/>
+    <!-- Misc -->
+    <rule ref="Security.Misc.BadCorsHeader"/>
+    <rule ref="Security.Misc.IncludeMismatch"/>
+    <rule ref="Security.Misc.TypeJuggle"/>
 
 </ruleset>
-

--- a/example_drupal7_ruleset.xml
+++ b/example_drupal7_ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="Drupal7Security">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Drupal7Security" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
  <description>Rules for Drupal 7 projects</description>
 <!-- Code Reviews Rules -->
 <!--

--- a/example_drupal7_ruleset.xml
+++ b/example_drupal7_ruleset.xml
@@ -1,79 +1,79 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Drupal7Security" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
- <description>Rules for Drupal 7 projects</description>
-<!-- Code Reviews Rules -->
-<!--
- <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
- <rule ref="PEAR"/>
--->
+    <description>Rules for Drupal 7 projects</description>
 
-<!-- Security Code Reviews Rules -->
+    <!-- Code Reviews Rules -->
+    <!--
+    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+    <rule ref="PEAR"/>
+    -->
 
-<!-- Global properties -->
-<!-- Please note that not every sniff uses them and they can be overwritten by rule -->
-<!-- Framework or CMS used. Must be a class under Security_Sniffs. -->
-<config name="CmsFramework" value="Drupal7"/>
-<!-- Paranoia mode: Will generate more alerts but will miss less vulnerabilites. Good for assisting manual code review. -->
-<config name="ParanoiaMode" value="1"/>
+    <!-- Security Code Reviews Rules -->
 
-<!-- BadFunctions -->
-<!-- PHP functions that can lead to security issues -->
-<rule ref="Security.BadFunctions.Asserts"/>
-<rule ref="Security.BadFunctions.Backticks"/>
-<rule ref="Security.BadFunctions.CallbackFunctions"/>
-<rule ref="Security.BadFunctions.CryptoFunctions"/>
-<rule ref="Security.BadFunctions.EasyRFI"/>
-<rule ref="Security.BadFunctions.EasyXSS"/>
-<rule ref="Security.BadFunctions.ErrorHandling"/>
-<rule ref="Security.BadFunctions.FilesystemFunctions"/>
-<rule ref="Security.BadFunctions.FringeFunctions"/>
-<rule ref="Security.BadFunctions.FunctionHandlingFunctions"/>
-<rule ref="Security.BadFunctions.Mysqli"/>
-<rule ref="Security.BadFunctions.NoEvals"/>
-<rule ref="Security.BadFunctions.Phpinfos"/>
-<rule ref="Security.BadFunctions.PregReplace"/>
-<rule ref="Security.BadFunctions.SQLFunctions"/>
-<rule ref="Security.BadFunctions.SystemExecFunctions"/>
+    <!-- Global properties. -->
+    <!-- Please note that not every sniff uses them and they can be overwritten per rule. -->
+    <!-- Framework or CMS used. Must be a class under Security_Sniffs. -->
+    <config name="CmsFramework" value="Drupal7"/>
+    <!-- Paranoia mode: Will generate more alerts but will miss less vulnerabilites. Good for assisting manual code review. -->
+    <config name="ParanoiaMode" value="1"/>
 
-<!-- CVE -->
-<!-- Entries from CVE database from vendor PHP and bugs.php.net -->
-<rule ref="Security.CVE.CVE20132110"/>
-<rule ref="Security.CVE.CVE20134113"/>
+    <!-- BadFunctions -->
+    <!-- PHP functions that can lead to security issues -->
+    <rule ref="Security.BadFunctions.Asserts"/>
+    <rule ref="Security.BadFunctions.Backticks"/>
+    <rule ref="Security.BadFunctions.CallbackFunctions"/>
+    <rule ref="Security.BadFunctions.CryptoFunctions"/>
+    <rule ref="Security.BadFunctions.EasyRFI"/>
+    <rule ref="Security.BadFunctions.EasyXSS"/>
+    <rule ref="Security.BadFunctions.ErrorHandling"/>
+    <rule ref="Security.BadFunctions.FilesystemFunctions"/>
+    <rule ref="Security.BadFunctions.FringeFunctions"/>
+    <rule ref="Security.BadFunctions.FunctionHandlingFunctions"/>
+    <rule ref="Security.BadFunctions.Mysqli"/>
+    <rule ref="Security.BadFunctions.NoEvals"/>
+    <rule ref="Security.BadFunctions.Phpinfos"/>
+    <rule ref="Security.BadFunctions.PregReplace"/>
+    <rule ref="Security.BadFunctions.SQLFunctions"/>
+    <rule ref="Security.BadFunctions.SystemExecFunctions"/>
 
-<!-- Misc -->
-<rule ref="Security.Misc.BadCorsHeader"/>
-<rule ref="Security.Misc.IncludeMismatch"/>
+    <!-- CVE -->
+    <!-- Entries from CVE database from vendor PHP and bugs.php.net. -->
+    <rule ref="Security.CVE.CVE20132110"/>
+    <rule ref="Security.CVE.CVE20134113"/>
 
-<!-- Drupal7 -->
-<!-- Specific security issues of Drupal7 and advisories  -->
-<rule ref="Security.Drupal7.AdvisoriesContrib">
-	<exclude-pattern>(?&lt;!\.info)$</exclude-pattern>
-</rule>
-<rule ref="Security.Drupal7.AdvisoriesCore">
-	<exclude-pattern>(?&lt;!includes\/bootstrap\.inc)$</exclude-pattern>
-</rule>
-<rule ref="Security.Drupal7.SQLi"/>
-<rule ref="Security.Drupal7.SQLi.D7NoDbQuery"/>
-<rule ref="Security.Drupal7.SQLi.D7DbQuerySQLi"/>
-<rule ref="Security.Drupal7.SQLi.D7DbQueryDirectVar"/>
-<rule ref="Security.Drupal7.XSSPTheme"/>
-<rule ref="Security.Drupal7.UserInputWatch">
-	<properties>
-		<property name="FormThreshold" value="10"/>
-		<property name="FormStateThreshold" value="10"/>
-	</properties>
-</rule>
-<rule ref="Security.Drupal7.XSSFormValue"/>
-<rule ref="Security.Drupal7.XSSHTMLConstruct"/>
-<rule ref="Security.Drupal7.DbQueryAC">
-	<properties>
-		<!-- Comment out to follow global ParanoiaMode -->
-		<property name="forceParanoia" value="1"/>
-	</properties>
-</rule>
-<rule ref="Security.Drupal7.DynQueries"/>
-<rule ref="Security.Drupal7.Cachei"/>
-<rule ref="Security.Drupal7.HttpRequest"/>
+    <!-- Misc -->
+    <rule ref="Security.Misc.BadCorsHeader"/>
+    <rule ref="Security.Misc.IncludeMismatch"/>
+
+    <!-- Drupal 7 -->
+    <!-- Specific security issues of Drupal7 and advisories.  -->
+    <rule ref="Security.Drupal7.AdvisoriesContrib">
+        <exclude-pattern>(?&lt;!\.info)$</exclude-pattern>
+    </rule>
+    <rule ref="Security.Drupal7.AdvisoriesCore">
+        <exclude-pattern>(?&lt;!includes\/bootstrap\.inc)$</exclude-pattern>
+    </rule>
+    <rule ref="Security.Drupal7.SQLi"/>
+    <rule ref="Security.Drupal7.SQLi.D7NoDbQuery"/>
+    <rule ref="Security.Drupal7.SQLi.D7DbQuerySQLi"/>
+    <rule ref="Security.Drupal7.SQLi.D7DbQueryDirectVar"/>
+    <rule ref="Security.Drupal7.XSSPTheme"/>
+    <rule ref="Security.Drupal7.UserInputWatch">
+        <properties>
+            <property name="FormThreshold" value="10"/>
+            <property name="FormStateThreshold" value="10"/>
+        </properties>
+    </rule>
+    <rule ref="Security.Drupal7.XSSFormValue"/>
+    <rule ref="Security.Drupal7.XSSHTMLConstruct"/>
+    <rule ref="Security.Drupal7.DbQueryAC">
+        <properties>
+            <!-- Comment out to follow global ParanoiaMode -->
+            <property name="forceParanoia" value="1"/>
+        </properties>
+    </rule>
+    <rule ref="Security.Drupal7.DynQueries"/>
+    <rule ref="Security.Drupal7.Cachei"/>
+    <rule ref="Security.Drupal7.HttpRequest"/>
 
 </ruleset>
-


### PR DESCRIPTION
Related to #56, this adds an initial set of CI checks to be run via Travis.

To turn this check on:
* Go to the Travis.com website.
* Log in via GitHub ID.
* Let it sync with GitHub to retrieve the repositories & turn the check on for this repo.

I've tested this PR - see here for a passing build: https://travis-ci.org/jrfnl/phpcs-security-audit/builds/651998291

### Rulesets: Add XSD schema tags (PHPCS 3.2+/3.3.2+)

As of PHPCS 3.2.0, PHPCS includes an XSD schema for rulesets which defines what can be used in the XML ruleset file.

In PHPCS 3.3.0 a new array format for properties was introduced and as of PHPCS 3.3.2, the new array format is now also covered by this schema.

This commit adds the schema tags to the `ruleset.xml` file and the example rulesets.

### Rulesets: tidy up

Tidy up the XML rulesets so they can pass validation against the XSD as well as for XML code style.

### QA: add Parallel-Lint for easy syntax checking of the repo

Includes adding a `composer lint` convenience script to run the command.

The script as-is, is platform independent and will work on both Linux, Mac as well as Windows and respects the PHP version used by Composer.

### Travis: add initial CI check

* Validate the `composer.json` file.
* Validate the XML ruleset files against the PHPCS XSD schema.
* Verify the XML code style consistency of the ruleset files.
* Run PHP linter over all PHP files on PHP 5.4, 7.4 and `nightly` (= PHP 8).

