### PR TITLE
Skip validating user defined functions which has similar name as file system function

### DIFF
--- a/Security/Sniffs/BadFunctions/FilesystemFunctionsSniff.php
+++ b/Security/Sniffs/BadFunctions/FilesystemFunctionsSniff.php
@@ -47,6 +47,11 @@ class FilesystemFunctionsSniff implements Sniff  {
 				return;
 			}
 
+			// Skip user defined functions which has similar names with a filesystem function.
+			if ($tokens[$stackPtr - 2]['content'] == 'function') {
+				return;
+			}
+
 			$closer = $tokens[$opener]['parenthesis_closer'];
 			$s = $phpcsFile->findNext(array_merge(\PHP_CodeSniffer\Util\Tokens::$emptyTokens, \PHP_CodeSniffer\Util\Tokens::$bracketTokens, \PHPCS_SecurityAudit\Security\Sniffs\Utils::$staticTokens), $s, $closer, true);
             if ($s) {


### PR DESCRIPTION
### Description

The Filesystem function sniff is also detecting and validating user defined functions even if the function is not a PHP native filesystem function.

Proposed fixed: Check if previous token is "function" to check if the function is user defined.

### Steps to reproduce:
1. Create a function called delete `function delete($myvalue) {}`
2. Run phpcs
3. It throws a warning `Filesystem function delete() detected with dynamic parameter`