### PR TITLE
Bug fix: Drupal8 utils not working

### DIFF
--- a/Security/Sniffs/Drupal8/Utils.php
+++ b/Security/Sniffs/Drupal8/Utils.php
@@ -1,7 +1,7 @@
 <?php
 namespace PHPCS_SecurityAudit\Security\Sniffs\Drupal8;
 
-class Utils extends PHPCS_SecurityAudit\Security\Sniffs\Symfony2\Utils {
+class Utils extends \PHPCS_SecurityAudit\Security\Sniffs\Symfony2\Utils {
 
 	/**
 	* Heavy used function to verify if a token contains user input


### PR DESCRIPTION
The Drupal8 framework setting hadn't been working for quite a while.

PR #50 already fixed part of this by adding the namespace, but as the name of class being extended was not fully qualified, this would now still not work correctly as it would look for a `PHPCS_SecurityAudit\Security\Sniffs\Drupal8\PHPCS_SecurityAudit\Security\Sniffs\Symfony2\Utils` class.

Changing the name of the class being extended to fully qualified, fixes this.