### PR TITLE
Initial unit test setup, including tests for the Backticks sniff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,9 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
+/phpunit.xml.dist export-ignore
+/phpunit-bootstrap.php export-ignore
+/Security/Tests/ export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor
 composer.lock
+/phpunit.xml
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,30 @@ cache:
 
 php:
   - 5.4
-  - 7.4
-  - "nightly"
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+
+env:
+  jobs:
+    # `master`
+    - PHPCS_VERSION="dev-master" LINT=1
+    # Lowest supported PHPCS version.
+    - PHPCS_VERSION="3.1.0"
 
 # Define the stages used.
+# For non-PRs, only the sniff and quicktest stages are run.
+# For pull requests and merges, the full script is run (skipping quicktest).
+# Note: for pull requests, "master" is the base branch name.
+# See: https://docs.travis-ci.com/user/conditions-v1
 stages:
   - name: sniff
+  - name: quicktest
+    if: type = push AND branch NOT IN (master)
   - name: test
+    if: branch IN (master)
 
 jobs:
   fast_finish: true
@@ -48,6 +65,37 @@ jobs:
         - diff -B ./example_base_ruleset.xml <(xmllint --format "./example_base_ruleset.xml")
         - diff -B ./example_drupal7_ruleset.xml <(xmllint --format "./example_drupal7_ruleset.xml")
 
+    #### QUICK TEST STAGE ####
+    # This is a much quicker test which only runs the unit tests and linting against the low/high
+    # supported PHP/PHPCS combinations.
+    - stage: quicktest
+      php: 7.4
+      env: PHPCS_VERSION="dev-master" LINT=1
+    - php: 7.2
+      # PHP 7.3 is only supported since PHPCS 3.3.1, PHP 7.4 since PHPCS 3.5.0, so running low against PHP 7.2.
+      env: PHPCS_VERSION="3.1.0"
+
+    - php: 5.4
+      env: PHPCS_VERSION="dev-master" LINT=1
+    - php: 5.4
+      env: PHPCS_VERSION="3.1.0"
+
+    #### TEST STAGE ####
+    # Additional builds to prevent issues with PHPCS versions incompatible with certain PHP versions.
+    # PHP 7.3 is only supported since PHPCS 3.3.1, PHP 7.4 since PHPCS 3.5.0.
+    - stage: test
+      php: 7.4
+      env: PHPCS_VERSION="dev-master" LINT=1
+    - php: 7.4
+      env: PHPCS_VERSION="3.5.0"
+    - php: 7.3
+      env: PHPCS_VERSION="dev-master" LINT=1
+    - php: 7.3
+      env: PHPCS_VERSION="3.3.1"
+
+    - php: "nightly"
+      env: PHPCS_VERSION="n/a" LINT=1
+
   allow_failures:
     # Allow failures for unstable builds.
     - php: "nightly"
@@ -58,9 +106,35 @@ before_install:
 
   - export XMLLINT_INDENT="    "
 
+  # On stable PHPCS versions, allow for PHP deprecation notices.
+  # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Sniff" && $PHPCS_BRANCH != "dev-master" && "$PHPCS_VERSION" != "n/a" ]]; then
+      echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    fi
+
+install:
+  # Set up test environment using Composer.
+  - |
+    if [[ $PHPCS_VERSION != "n/a" ]]; then
+      composer require --no-update --no-scripts squizlabs/php_codesniffer:${PHPCS_VERSION}
+    fi
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Sniff" || $PHPCS_VERSION == "n/a" ]]; then
+      # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
+      # The build on nightly also doesn't run the tests (yet).
+      composer remove --dev phpunit/phpunit --no-update --no-scripts
+    fi
+
   # --prefer-dist will allow for optimal use of the travis caching ability.
   - composer install --prefer-dist --no-suggest
 
 script:
   # Lint PHP files against parse errors.
-  - composer lint
+  - if [[ "$LINT" == "1" ]]; then composer lint; fi
+
+  # Run the unit tests.
+  - |
+    if [[ $PHPCS_VERSION != "n/a" ]]; then
+      composer test
+    fi

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ phpcs-security-audit in its beginning was backed by Pheromone (later on named Fl
 Install
 -------
 
-Requires [PHP CodeSniffer](http://pear.php.net/package/PHP_CodeSniffer/) version 3.x with PHP 5.4 or higher.
+Requires [PHP CodeSniffer](http://pear.php.net/package/PHP_CodeSniffer/) version 3.1.0 or higher with PHP 5.4 or higher.
 
 The easiest way to install is using [Composer](https://getcomposer.org/):
 ```bash

--- a/Security/Sniffs/BadFunctions/BackticksSniff.php
+++ b/Security/Sniffs/BadFunctions/BackticksSniff.php
@@ -37,9 +37,9 @@ class BackticksSniff implements Sniff {
 		while (($s = $phpcsFile->findNext(T_VARIABLE, ($s + 1), $closer)) !== false) {
 			$msg = 'System execution with backticks detected with dynamic parameter';
 			if ($utils::is_token_user_input($tokens[$s])) {
-				$phpcsFile->addError($msg . ' directly from user input', $stackPtr, 'ErrSystemExec');
+				$phpcsFile->addError($msg . ' directly from user input', $s, 'ErrSystemExec');
 			} else {
-				$phpcsFile->addWarning($msg, $stackPtr, 'WarnSystemExec');
+				$phpcsFile->addWarning($msg, $s, 'WarnSystemExec');
 			}
 		}
 

--- a/Security/Sniffs/BadFunctions/BackticksSniff.php
+++ b/Security/Sniffs/BadFunctions/BackticksSniff.php
@@ -28,13 +28,13 @@ class BackticksSniff implements Sniff {
 	public function process(File $phpcsFile, $stackPtr) {
 		$utils = \PHPCS_SecurityAudit\Security\Sniffs\UtilsFactory::getInstance();
 		$tokens = $phpcsFile->getTokens();
-        $closer = $phpcsFile->findNext(T_BACKTICK, $stackPtr + 1, null, false, null, true);
+		$closer = $phpcsFile->findNext(T_BACKTICK, $stackPtr + 1, null, false, null, true);
 		if (!$closer) {
 			return;
 		}
-        $s = $stackPtr + 1;
-		$s = $phpcsFile->findNext(T_VARIABLE, $s, $closer);
-        if ($s) {
+
+		$s = $stackPtr;
+		while (($s = $phpcsFile->findNext(T_VARIABLE, ($s + 1), $closer)) !== false) {
 			$msg = 'System execution with backticks detected with dynamic parameter';
 			if ($utils::is_token_user_input($tokens[$s])) {
 				$phpcsFile->addError($msg . ' directly from user input', $stackPtr, 'ErrSystemExec');

--- a/Security/Sniffs/BadFunctions/BackticksSniff.php
+++ b/Security/Sniffs/BadFunctions/BackticksSniff.php
@@ -26,14 +26,14 @@ class BackticksSniff implements Sniff {
 	* @return void
 	*/
 	public function process(File $phpcsFile, $stackPtr) {
-		$utils = \PHPCS_SecurityAudit\Security\Sniffs\UtilsFactory::getInstance();
-		$tokens = $phpcsFile->getTokens();
 		$closer = $phpcsFile->findNext(T_BACKTICK, $stackPtr + 1, null, false, null, true);
 		if (!$closer) {
 			return;
 		}
 
-		$s = $stackPtr;
+		$utils  = \PHPCS_SecurityAudit\Security\Sniffs\UtilsFactory::getInstance();
+		$tokens = $phpcsFile->getTokens();
+		$s      = $stackPtr;
 		while (($s = $phpcsFile->findNext(T_VARIABLE, ($s + 1), $closer)) !== false) {
 			$msg = 'System execution with backticks detected with dynamic parameter';
 			if ($utils::is_token_user_input($tokens[$s])) {

--- a/Security/Tests/AbstractSecurityTestCase.php
+++ b/Security/Tests/AbstractSecurityTestCase.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * An abstract class that all Security sniff unit tests must extend.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings that are not found, as well as
+ * unexpected warnings and errors, are considered test failures.
+ *
+ * This class will take care of setting the configuration variables in PHP_CodeSniffer
+ * needed to test all relevant configuration combinations for each sniff in
+ * the Security standard.
+ *
+ * The configuration variables set are based on the file name of a test case file.
+ *
+ * Naming conventions for the test case files:
+ * SniffNameUnitTest[.CmsFramework][.ParanoiaMode].inc
+ *
+ * Both `[.CmsFramework]` as well as `[.ParanoiaMode]` are optional.
+ * If neither is set, the defaults of no CmsFramework and Paranoia level 0 will be used.
+ *
+ * Separate test case files for different paranoia levels and different frameworks are
+ * only needed if the sniff behaves differently based on these settings.
+ *
+ * - If the sniff behaviour is the same all round, just having one plain `SniffNameUnitTest.inc`
+ *   test case file will be sufficient.
+ * - If the sniff behaviour is only dependent on one of the two configuration settings,
+ *   the other can be left out.
+ *   Examples:
+ *   - Sniff behaviour only depends on `ParanoiaMode`: `SniffNameUnitTest.[01].inc`.
+ *   - Sniff behaviour only depends on `CmsFramework`: `SniffNameUnitTest.[CmsFramework].inc`.
+ */
+
+namespace PHPCS_SecurityAudit\Security\Tests;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+abstract class AbstractSecurityTestCase extends AbstractSniffUnitTest
+{
+
+	/**
+	 * Get a list of CLI values to set before the file is tested.
+	 *
+	 * @param string                  $filename The name of the file being tested.
+	 * @param \PHP_CodeSniffer\Config $config   The config data for the run.
+	 *
+	 * @return void
+	 */
+	public function setCliValues($filename, $config)
+	{
+		// Set paranoia level.
+		$paranoia = substr($filename, (strlen($filename) - 5), 1);
+		if ($paranoia === '1') {
+			$config->setConfigData('ParanoiaMode', 1, true);
+		} else {
+			$config->setConfigData('ParanoiaMode', 0, true);
+		}
+
+		// Set the CMS Framework if necessary.
+		$firstDot    = strpos($filename, '.');
+		$firstOffset = ($firstDot + 1);
+		$secondDot   = strpos($filename, '.', $firstOffset);
+
+		$extendedExtension = '';
+		if ($secondDot !== false) {
+			$extendedExtension = substr($filename, $firstOffset, ($secondDot - $firstOffset));
+		}
+
+		switch ($extendedExtension) {
+			case 'Drupal7':
+				$config->setConfigData('CmsFramework', 'Drupal7', true);
+				break;
+
+			case 'Drupal8':
+				$config->setConfigData('CmsFramework', 'Drupal8', true);
+				break;
+
+			case 'Symfony2':
+				$config->setConfigData('CmsFramework', 'Symfony2', true);
+				break;
+
+			default:
+				$config->setConfigData('CmsFramework', null, true);
+				break;
+		}
+	}
+}

--- a/Security/Tests/BadFunctions/BackticksUnitTest.Drupal7.inc
+++ b/Security/Tests/BadFunctions/BackticksUnitTest.Drupal7.inc
@@ -1,0 +1,5 @@
+<?php
+
+$output = `$form['field']`; // Error (user input).
+$output = `$request['field']`; // Warning.
+`$_GET`; // Error (user input).

--- a/Security/Tests/BadFunctions/BackticksUnitTest.Drupal8.inc
+++ b/Security/Tests/BadFunctions/BackticksUnitTest.Drupal8.inc
@@ -1,0 +1,5 @@
+<?php
+
+$output = `$form['field']`; // Error (user input).
+$output = `$request['field']`; // Error (user input).
+`$_GET`; // Error (user input).

--- a/Security/Tests/BadFunctions/BackticksUnitTest.Symfony2.inc
+++ b/Security/Tests/BadFunctions/BackticksUnitTest.Symfony2.inc
@@ -1,0 +1,5 @@
+<?php
+
+$output = `$form['field']`; // Warning.
+$output = `$request['field']`; // Error (user input).
+`$_GET`; // Error (user input).

--- a/Security/Tests/BadFunctions/BackticksUnitTest.inc
+++ b/Security/Tests/BadFunctions/BackticksUnitTest.inc
@@ -12,6 +12,10 @@ $output = `git blame --date=short "$filename"`; // Warning.
 
 $output = `git blame --date=$_POST['key'] "$filename"`; // Warning + error.
 
+$output = `git blame
+	--date=$_POST['key'] // Error.
+	"$filename"`; // Warning.
+
 // Incomplete command. Ignore.
 // Intentional parse error. This should be the last test in the file.
 $output = `ls

--- a/Security/Tests/BadFunctions/BackticksUnitTest.inc
+++ b/Security/Tests/BadFunctions/BackticksUnitTest.inc
@@ -1,0 +1,15 @@
+<?php
+
+// Not using variable input.
+$output = `ls -al`;
+
+// These should all give an error/warning.
+$output = `$form['field']`; // Warning.
+$output = `$request['field']`; // Warning.
+`$_GET`; // Error (user input).
+
+$output = `git blame --date=short "$filename"`; // Warning.
+
+// Incomplete command. Ignore.
+// Intentional parse error. This should be the last test in the file.
+$output = `ls

--- a/Security/Tests/BadFunctions/BackticksUnitTest.inc
+++ b/Security/Tests/BadFunctions/BackticksUnitTest.inc
@@ -10,6 +10,8 @@ $output = `$request['field']`; // Warning.
 
 $output = `git blame --date=short "$filename"`; // Warning.
 
+$output = `git blame --date=$_POST['key'] "$filename"`; // Warning + error.
+
 // Incomplete command. Ignore.
 // Intentional parse error. This should be the last test in the file.
 $output = `ls

--- a/Security/Tests/BadFunctions/BackticksUnitTest.php
+++ b/Security/Tests/BadFunctions/BackticksUnitTest.php
@@ -26,6 +26,7 @@ class BackticksUnitTest extends AbstractSecurityTestCase
 			case 'BackticksUnitTest.inc':
 				return [
 					9  => 1,
+					13 => 1,
 				];
 
 			case 'BackticksUnitTest.Drupal7.inc':
@@ -70,6 +71,7 @@ class BackticksUnitTest extends AbstractSecurityTestCase
 					7  => 1,
 					8  => 1,
 					11 => 1,
+					13 => 1,
 				];
 
 			case 'BackticksUnitTest.Drupal7.inc':

--- a/Security/Tests/BadFunctions/BackticksUnitTest.php
+++ b/Security/Tests/BadFunctions/BackticksUnitTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Unit test class for the Backticks sniff.
+ */
+
+namespace PHPCS_SecurityAudit\Security\Tests\BadFunctions;
+
+use PHPCS_SecurityAudit\Security\Tests\AbstractSecurityTestCase;
+
+class BackticksUnitTest extends AbstractSecurityTestCase
+{
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getErrorList($testFile = '')
+	{
+		switch ($testFile) {
+			case 'BackticksUnitTest.inc':
+				return [
+					9  => 1,
+				];
+
+			case 'BackticksUnitTest.Drupal7.inc':
+				return [
+					3 => 1,
+					5 => 1,
+				];
+
+			case 'BackticksUnitTest.Drupal8.inc':
+				return [
+					3 => 1,
+					4 => 1,
+					5 => 1,
+				];
+
+			case 'BackticksUnitTest.Symfony2.inc':
+				return [
+					4 => 1,
+					5 => 1,
+				];
+
+			default:
+				return [];
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getWarningList($testFile = '')
+	{
+		switch ($testFile) {
+			case 'BackticksUnitTest.inc':
+				return [
+					7  => 1,
+					8  => 1,
+					11 => 1,
+				];
+
+			case 'BackticksUnitTest.Drupal7.inc':
+				return [
+					4 => 1,
+				];
+
+			case 'BackticksUnitTest.Symfony2.inc':
+				return [
+					3 => 1,
+				];
+
+			default:
+				return [];
+		}
+	}
+}

--- a/Security/Tests/BadFunctions/BackticksUnitTest.php
+++ b/Security/Tests/BadFunctions/BackticksUnitTest.php
@@ -27,6 +27,7 @@ class BackticksUnitTest extends AbstractSecurityTestCase
 				return [
 					9  => 1,
 					13 => 1,
+					16 => 1,
 				];
 
 			case 'BackticksUnitTest.Drupal7.inc':
@@ -72,6 +73,7 @@ class BackticksUnitTest extends AbstractSecurityTestCase
 					8  => 1,
 					11 => 1,
 					13 => 1,
+					17 => 1,
 				];
 
 			case 'BackticksUnitTest.Drupal7.inc':

--- a/composer.json
+++ b/composer.json
@@ -11,18 +11,22 @@
     ],
     "require": {
         "php": ">=5.4",
-        "squizlabs/php_codesniffer": "^3.0.2",
+        "squizlabs/php_codesniffer": "^3.1.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6"
     },
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.0",
-        "php-parallel-lint/php-console-highlighter": "^0.4"
+        "php-parallel-lint/php-console-highlighter": "^0.4",
+        "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts" : {
         "lint": [
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+        ],
+        "test": [
+            "@php ./vendor/phpunit/phpunit/phpunit --filter Security ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
         ]
     }
 }

--- a/phpunit-bootstrap.php
+++ b/phpunit-bootstrap.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Bootstrap file for running the tests.
+ *
+ * - Load the PHPCS PHPUnit bootstrap file providing cross-version PHPUnit support.
+ *   {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1384}
+ * - Allows for a `PHPCS_DIR` environment variable to be set to point to a different
+ *   PHPCS install than the one in the `vendor` directory to allow for testing with
+ *   a git clone of PHPCS in a local develop environment.
+ * - Prevent attempting to run unit tests of other external PHPCS standards installed.
+ */
+
+if (\defined('PHP_CODESNIFFER_IN_TESTS') === false) {
+	\define('PHP_CODESNIFFER_IN_TESTS', true);
+}
+
+$ds = \DIRECTORY_SEPARATOR;
+
+/*
+ * Load the necessary PHPCS files.
+ */
+// Get the PHPCS dir from an environment variable.
+$phpcsDir          = \getenv('PHPCS_DIR');
+$composerPHPCSPath = __DIR__ . $ds . 'vendor' . $ds . 'squizlabs' . $ds . 'php_codesniffer';
+
+if ($phpcsDir === false && \is_dir($composerPHPCSPath)) {
+	// PHPCS installed via Composer.
+	$phpcsDir = $composerPHPCSPath;
+} elseif ($phpcsDir !== false) {
+	/*
+	 * PHPCS in a custom directory.
+	 * For this to work, the `PHPCS_DIR` variable needs to be set in a custom `phpunit.xml` file.
+	 */
+	$phpcsDir = \realpath($phpcsDir);
+}
+
+// Try and load the PHPCS autoloader.
+if ($phpcsDir !== false
+	&& \file_exists($phpcsDir . $ds . 'autoload.php')
+	&& \file_exists($phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php')
+) {
+	require_once $phpcsDir . $ds . 'autoload.php';
+	require_once $phpcsDir . $ds . 'tests' . $ds . 'bootstrap.php'; // PHPUnit 6.x+ support.
+} else {
+	echo 'Uh oh... can\'t find PHPCS.
+
+If you use Composer, please run `composer install`.
+Otherwise, make sure you set a `PHPCS_DIR` environment variable in your phpunit.xml file
+pointing to the PHPCS directory.
+';
+
+	die(1);
+}
+
+/*
+ * Set the PHPCS_IGNORE_TEST environment variable to ignore tests from other standards.
+ */
+$securityStandards = [
+	'Security' => true,
+];
+
+$allStandards   = PHP_CodeSniffer\Util\Standards::getInstalledStandards();
+$allStandards[] = 'Generic';
+
+$standardsToIgnore = [];
+foreach ($allStandards as $standard) {
+	if (isset($securityStandards[$standard]) === true) {
+		continue;
+	}
+
+	$standardsToIgnore[] = $standard;
+}
+
+$standardsToIgnoreString = \implode(',', $standardsToIgnore);
+\putenv("PHPCS_IGNORE_TESTS={$standardsToIgnoreString}");
+
+// Clean up.
+unset($ds, $phpcsDir, $composerPHPCSPath, $allStandards, $standardsToIgnore, $standard, $standardsToIgnoreString);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.5/phpunit.xsd"
+    backupGlobals="true"
+    bootstrap="./phpunit-bootstrap.php"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+    colors="true"
+    forceCoversAnnotation="true">
+
+    <testsuites>
+        <testsuite name="Security">
+            <directory suffix="UnitTest.php">./Security/Tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
This is an initial setup for the unit tests.

To allow for testing with different configuration variables - `ParanoiaMode` and `CmsFramework` -, I've chosen to create a setup which will automatically set these variables based on the test case file name.

This initial setup includes unit tests for the `BadFunctions.Backticks` sniff, as well as three commits making small fixes to the sniff.

Related to #57

# Commit summary

## CI: Initial unit test setup

* Adds PHPUnit to the `dev` requirements in the `composer.json` file.
    - As the PHPCS PHPUnit framework isn't compatible with PHPUnit 7 until PHPCS 3.2.3, I've chosen to explicitly only support PHPUnit 4, 5, 6 via Composer to prevent having to make extra allowances for PHPUnit 7 in the Travis script.
    - Includes raising the minimum PHPCS requirement from PHPCS `3.0.2` to `3.1.0` as PHPCS `3.0.2` does not yet contain the PHPUnit `bootstrap.php` file for cross-version PHPUnit compatibility.
    - Includes adding a convenience script to easily run the unit tests.
* Adds a `phpunit.xml.dist` configuration file.
* Adds a `phpunit-bootstrap.php` file to sort out the autoloading for the unit tests and to prevent PHPCS from trying to run unit tests for other installed external standards.
* Adds an abstract base test case for the security sniffs which handles setting the configuration variables for the tests.
    The configuration variables are set based on the test case file name. See the explanation in the file docblock.
* Adds running the unit tests to the Travis configuration.
    As the full unit test matrix can take a little while to run, I've set this up in a way that on pushes only a quick check is being run and that the full build is only run on PRs and merges to `master`.
    The updated build matrix takes compatibility of PHPCS with various PHP versions into account.

Includes:
* Adding the test related files to the `.gitattributes` `export-ignore` list so they don't get shipped in the release packages.
* Adding typical PHPUnit overload/cache files to the `.gitignore` file.

## BadFunctions/Backticks: add unit tests

## BadFunctions/Backticks: bug fix - report on each variable

The sniff would only report on the first variable found in the shell command, not on each variable.

Even though there would be a notice, the level could have been `warning` as the first variable seen was a non-user input variable, while a more serious `error` for a subsequently used user input variable would not be reported.

This has now been fixed by changing the check for a variable to a loop which will report a separate error/warning for each variable encountered in the command.

## BadFunctions/Backticks: error message line precision

A backtick-shell command can be spread out over several lines.

This minor change make it so the error/warning will be reported on the line containing the offending variable, not the line containing the open-backtick, as these may not be the same.

## BadFunctions/Backticks: minor efficiency fix

Only set variables if they are actually needed, not before.

