### PR TITLE
BadFunctions/EasyRFI: add unit tests, includes various bug fixes

### DIFF
--- a/Security/Sniffs/BadFunctions/EasyRFISniff.php
+++ b/Security/Sniffs/BadFunctions/EasyRFISniff.php
@@ -38,7 +38,7 @@ class EasyRFISniff implements Sniff {
 	* @return void
 	*/
 	public function process(File $phpcsFile, $stackPtr) {
-		$closer = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr + 1));
+		$closer = $phpcsFile->findNext(array(T_SEMICOLON, T_CLOSE_TAG), ($stackPtr + 1));
 		if ($closer === false) {
 			// Live coding or parse error.
 			return;

--- a/Security/Sniffs/BadFunctions/EasyRFISniff.php
+++ b/Security/Sniffs/BadFunctions/EasyRFISniff.php
@@ -48,19 +48,18 @@ class EasyRFISniff implements Sniff {
 		$tokens = $phpcsFile->getTokens();
 		$s      = $stackPtr;
 
-		while ($s) {
-			$s = $phpcsFile->findNext($this->search, $s + 1, $closer, true);
 
+		while (($s = $phpcsFile->findNext($this->search, $s + 1, $closer, true)) !== false) {
 			$data = array(
 				$tokens[$s]['content'],
 				$tokens[$stackPtr]['content'],
 			);
 
-			if ($s && $utils::is_token_user_input($tokens[$s])) {
+			if ($utils::is_token_user_input($tokens[$s])) {
 				if (\PHP_CodeSniffer\Config::getConfigData('ParanoiaMode') || !$utils::is_token_false_positive($tokens[$s], $tokens[$s+2])) {
 					$phpcsFile->addError('Easy RFI detected because of direct user input with %s on %s', $s, 'ErrEasyRFI', $data);
 				}
-			} elseif ($s && \PHP_CodeSniffer\Config::getConfigData('ParanoiaMode') && $tokens[$s]['content'] != '.') {
+			} elseif (\PHP_CodeSniffer\Config::getConfigData('ParanoiaMode') && $tokens[$s]['content'] != '.') {
 				$phpcsFile->addWarning('Possible RFI detected with %s on %s', $s, 'WarnEasyRFI', $data);
 			}
 		}

--- a/Security/Sniffs/BadFunctions/EasyRFISniff.php
+++ b/Security/Sniffs/BadFunctions/EasyRFISniff.php
@@ -38,16 +38,12 @@ class EasyRFISniff implements Sniff {
 	* @return void
 	*/
 	public function process(File $phpcsFile, $stackPtr) {
-		$utils = \PHPCS_SecurityAudit\Security\Sniffs\UtilsFactory::getInstance();
-		$tokens = $phpcsFile->getTokens();
-		$s = $phpcsFile->findNext(\PHP_CodeSniffer\Util\Tokens::$emptyTokens, $stackPtr, null, true, null, true);
+		$closer = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr + 1));
 
-		if ($tokens[$s]['code'] == T_OPEN_PARENTHESIS) {
-			$closer = $tokens[$s]['parenthesis_closer'];
-		} else {
-			$closer = $phpcsFile->findNext(T_SEMICOLON, $stackPtr);
-			$s = $stackPtr;
-		}
+		$utils  = \PHPCS_SecurityAudit\Security\Sniffs\UtilsFactory::getInstance();
+		$tokens = $phpcsFile->getTokens();
+		$s      = $stackPtr;
+
 		while ($s) {
 			$s = $phpcsFile->findNext($this->search, $s + 1, $closer, true);
 

--- a/Security/Sniffs/BadFunctions/EasyRFISniff.php
+++ b/Security/Sniffs/BadFunctions/EasyRFISniff.php
@@ -39,6 +39,10 @@ class EasyRFISniff implements Sniff {
 	*/
 	public function process(File $phpcsFile, $stackPtr) {
 		$closer = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr + 1));
+		if ($closer === false) {
+			// Live coding or parse error.
+			return;
+		}
 
 		$utils  = \PHPCS_SecurityAudit\Security\Sniffs\UtilsFactory::getInstance();
 		$tokens = $phpcsFile->getTokens();

--- a/Security/Sniffs/BadFunctions/EasyRFISniff.php
+++ b/Security/Sniffs/BadFunctions/EasyRFISniff.php
@@ -25,7 +25,7 @@ class EasyRFISniff implements Sniff {
 		$this->search += \PHP_CodeSniffer\Util\Tokens::$bracketTokens;
 		$this->search += \PHPCS_SecurityAudit\Security\Sniffs\Utils::$staticTokens;
 
-		return array(T_INCLUDE, T_INCLUDE_ONCE, T_REQUIRE, T_REQUIRE_ONCE);
+		return \PHP_CodeSniffer\Util\Tokens::$includeTokens;
 	}
 
 	/**

--- a/Security/Sniffs/BadFunctions/EasyRFISniff.php
+++ b/Security/Sniffs/BadFunctions/EasyRFISniff.php
@@ -24,6 +24,7 @@ class EasyRFISniff implements Sniff {
 		$this->search  = \PHP_CodeSniffer\Util\Tokens::$emptyTokens;
 		$this->search += \PHP_CodeSniffer\Util\Tokens::$bracketTokens;
 		$this->search += \PHPCS_SecurityAudit\Security\Sniffs\Utils::$staticTokens;
+		$this->search[T_STRING_CONCAT] = T_STRING_CONCAT;
 
 		return \PHP_CodeSniffer\Util\Tokens::$includeTokens;
 	}
@@ -59,7 +60,7 @@ class EasyRFISniff implements Sniff {
 				if (\PHP_CodeSniffer\Config::getConfigData('ParanoiaMode') || !$utils::is_token_false_positive($tokens[$s], $tokens[$s+2])) {
 					$phpcsFile->addError('Easy RFI detected because of direct user input with %s on %s', $s, 'ErrEasyRFI', $data);
 				}
-			} elseif (\PHP_CodeSniffer\Config::getConfigData('ParanoiaMode') && $tokens[$s]['content'] != '.') {
+			} elseif (\PHP_CodeSniffer\Config::getConfigData('ParanoiaMode')) {
 				$phpcsFile->addWarning('Possible RFI detected with %s on %s', $s, 'WarnEasyRFI', $data);
 			}
 		}

--- a/Security/Sniffs/BadFunctions/EasyRFISniff.php
+++ b/Security/Sniffs/BadFunctions/EasyRFISniff.php
@@ -50,12 +50,18 @@ class EasyRFISniff implements Sniff {
 		}
 		while ($s) {
 			$s = $phpcsFile->findNext($this->search, $s + 1, $closer, true);
+
+			$data = array(
+				$tokens[$s]['content'],
+				$tokens[$stackPtr]['content'],
+			);
+
 			if ($s && $utils::is_token_user_input($tokens[$s])) {
 				if (\PHP_CodeSniffer\Config::getConfigData('ParanoiaMode') || !$utils::is_token_false_positive($tokens[$s], $tokens[$s+2])) {
-					$phpcsFile->addError('Easy RFI detected because of direct user input with ' . $tokens[$s]['content'] . ' on ' . $tokens[$stackPtr]['content'], $s, 'ErrEasyRFI');
+					$phpcsFile->addError('Easy RFI detected because of direct user input with %s on %s', $s, 'ErrEasyRFI', $data);
 				}
 			} elseif ($s && \PHP_CodeSniffer\Config::getConfigData('ParanoiaMode') && $tokens[$s]['content'] != '.') {
-				$phpcsFile->addWarning('Possible RFI detected with ' . $tokens[$s]['content'] . ' on ' . $tokens[$stackPtr]['content'], $s, 'WarnEasyRFI');
+				$phpcsFile->addWarning('Possible RFI detected with %s on %s', $s, 'WarnEasyRFI', $data);
 			}
 		}
 	}

--- a/Security/Sniffs/Utils.php
+++ b/Security/Sniffs/Utils.php
@@ -3,7 +3,12 @@ namespace PHPCS_SecurityAudit\Security\Sniffs;
 class Utils {
 
 	// Tokens that can't containts or use any variables (so no user input)
-	public static $staticTokens = array(T_CONSTANT_ENCAPSED_STRING, T_COMMA, T_LNUMBER, T_DNUMBER);
+	public static $staticTokens = array(
+		T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
+		T_COMMA                    => T_COMMA,
+		T_LNUMBER                  => T_LNUMBER,
+		T_DNUMBER                  => T_DNUMBER,
+	);
 
 	/**
 	* Heavy used function to verify if a string from a token contains user input

--- a/Security/Tests/BadFunctions/EasyRFIUnitTest.0.inc
+++ b/Security/Tests/BadFunctions/EasyRFIUnitTest.0.inc
@@ -16,5 +16,10 @@ include arg(2) . drupal_get_query_parameters()['param'];
 // Prevent false positives on safe $_SERVER variables.
 include $_SERVER['DOCUMENT_ROOT'] . '/filename.php';
 
+?>
+<?php include $_POST['path'] ?><!-- Error. -->
+<?php
+echo function_call($param);
+
 // Intentional parse error. This should be the last test in the file.
 require_once

--- a/Security/Tests/BadFunctions/EasyRFIUnitTest.0.inc
+++ b/Security/Tests/BadFunctions/EasyRFIUnitTest.0.inc
@@ -6,7 +6,7 @@
 
 // Base.
 include ( 'path/to/' . $_GET['filename'] ); // Error.
-include_once 'path/to/' . "$filename" . '.' . $extension;
+include_once ('path/to/' . "$filename") . '.' . $extension;
 require getenv('PATHTOFILE'); // Error.
 
 // Drupal 7.

--- a/Security/Tests/BadFunctions/EasyRFIUnitTest.0.inc
+++ b/Security/Tests/BadFunctions/EasyRFIUnitTest.0.inc
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * Paranoia mode = 0.
+ */
+
+// Base.
+include ( 'path/to/' . $_GET['filename'] ); // Error.
+include_once 'path/to/' . "$filename" . '.' . $extension;
+require getenv('PATHTOFILE'); // Error.
+
+// Drupal 7.
+require_once ( 'path/to/' . $form['filename'] );
+include arg(2) . drupal_get_query_parameters()['param'];
+
+// Prevent false positives on safe $_SERVER variables.
+include $_SERVER['DOCUMENT_ROOT'] . '/filename.php';

--- a/Security/Tests/BadFunctions/EasyRFIUnitTest.0.inc
+++ b/Security/Tests/BadFunctions/EasyRFIUnitTest.0.inc
@@ -15,3 +15,6 @@ include arg(2) . drupal_get_query_parameters()['param'];
 
 // Prevent false positives on safe $_SERVER variables.
 include $_SERVER['DOCUMENT_ROOT'] . '/filename.php';
+
+// Intentional parse error. This should be the last test in the file.
+require_once

--- a/Security/Tests/BadFunctions/EasyRFIUnitTest.1.inc
+++ b/Security/Tests/BadFunctions/EasyRFIUnitTest.1.inc
@@ -16,5 +16,10 @@ include arg(2) . drupal_get_query_parameters()['param']; // Warning x 2.
 // Prevent false positives on safe $_SERVER variables.
 include $_SERVER['DOCUMENT_ROOT'] . '/filename.php'; // Error.
 
+?>
+<?php include $_POST['path'] ?><!-- Error. -->
+<?php
+echo function_call($param);
+
 // Intentional parse error. This should be the last test in the file.
 require $_GET['path']

--- a/Security/Tests/BadFunctions/EasyRFIUnitTest.1.inc
+++ b/Security/Tests/BadFunctions/EasyRFIUnitTest.1.inc
@@ -15,3 +15,6 @@ include arg(2) . drupal_get_query_parameters()['param']; // Warning x 2.
 
 // Prevent false positives on safe $_SERVER variables.
 include $_SERVER['DOCUMENT_ROOT'] . '/filename.php'; // Error.
+
+// Intentional parse error. This should be the last test in the file.
+require $_GET['path']

--- a/Security/Tests/BadFunctions/EasyRFIUnitTest.1.inc
+++ b/Security/Tests/BadFunctions/EasyRFIUnitTest.1.inc
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * Paranoia mode = 1.
+ */
+ 
+// Base.
+include ( 'path/to/' . $_GET['filename'] ); // Error.
+include 'path/to/' . "$filename" . '.' . $extension; // Warning x 2.
+include getenv('PATHTOFILE'); // Error.
+
+// Drupal 7.
+include ( 'path/to/' . $form['filename'] ); // Warning.
+include arg(2) . drupal_get_query_parameters()['param']; // Warning x 2.
+
+// Prevent false positives on safe $_SERVER variables.
+include $_SERVER['DOCUMENT_ROOT'] . '/filename.php'; // Error.

--- a/Security/Tests/BadFunctions/EasyRFIUnitTest.1.inc
+++ b/Security/Tests/BadFunctions/EasyRFIUnitTest.1.inc
@@ -6,7 +6,7 @@
  
 // Base.
 include ( 'path/to/' . $_GET['filename'] ); // Error.
-include 'path/to/' . "$filename" . '.' . $extension; // Warning x 2.
+include ('path/to/' . "$filename") . '.' . $extension; // Warning x 2.
 include getenv('PATHTOFILE'); // Error.
 
 // Drupal 7.

--- a/Security/Tests/BadFunctions/EasyRFIUnitTest.Drupal7.1.inc
+++ b/Security/Tests/BadFunctions/EasyRFIUnitTest.Drupal7.1.inc
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Paranoia mode = 1, CmsFramework = Drupal7.
+ */
+ 
+// Base.
+include ( 'path/to/' . $_GET['filename'] ); // Error.
+include 'path/to/' . "$filename" . '.' . $extension; // Warning x 2.
+include getenv('PATHTOFILE'); // Error.
+
+// Drupal 7.
+include ( 'path/to/' . $form['filename'] ); // Error.
+include arg(2) . drupal_get_query_parameters()['param']; // Error x 2.

--- a/Security/Tests/BadFunctions/EasyRFIUnitTest.Drupal7.1.inc
+++ b/Security/Tests/BadFunctions/EasyRFIUnitTest.Drupal7.1.inc
@@ -12,3 +12,6 @@ include getenv('PATHTOFILE'); // Error.
 // Drupal 7.
 include ( 'path/to/' . $form['filename'] ); // Error.
 include arg(2) . drupal_get_query_parameters()['param']; // Error x 2.
+
+// Intentional parse error. This should be the last test in the file.
+include_once ( $_GET['path']

--- a/Security/Tests/BadFunctions/EasyRFIUnitTest.Drupal7.1.inc
+++ b/Security/Tests/BadFunctions/EasyRFIUnitTest.Drupal7.1.inc
@@ -6,7 +6,7 @@
  
 // Base.
 include ( 'path/to/' . $_GET['filename'] ); // Error.
-include 'path/to/' . "$filename" . '.' . $extension; // Warning x 2.
+include ('path/to/' . "$filename") . '.' . $extension; // Warning x 2.
 include getenv('PATHTOFILE'); // Error.
 
 // Drupal 7.

--- a/Security/Tests/BadFunctions/EasyRFIUnitTest.php
+++ b/Security/Tests/BadFunctions/EasyRFIUnitTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace PHPCS_SecurityAudit\Security\Tests\BadFunctions;
+
+use PHPCS_SecurityAudit\Security\Tests\AbstractSecurityTestCase;
+
+/**
+ * Unit test class for the EasyRFI sniff.
+ *
+ * @covers \PHPCS_SecurityAudit\Security\Sniffs\BadFunctions\EasyRFISniff
+ */
+class EasyRFIUnitTest extends AbstractSecurityTestCase
+{
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getErrorList($testFile = '')
+	{
+		switch ($testFile) {
+			case 'EasyRFIUnitTest.0.inc':
+				return [
+					8  => 1,
+					10 => 1,
+				];
+
+			case 'EasyRFIUnitTest.1.inc':
+				return [
+					8  => 1,
+					10 => 1,
+					17 => 1,
+				];
+
+			case 'EasyRFIUnitTest.Drupal7.1.inc':
+				return [
+					8  => 1,
+					10 => 1,
+					13 => 1,
+					14 => 2,
+				];
+
+			default:
+				return [];
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getWarningList($testFile = '')
+	{
+		switch ($testFile) {
+			case 'EasyRFIUnitTest.1.inc':
+				return [
+					9  => 2,
+					13 => 1,
+					14 => 2,
+				];
+
+			case 'EasyRFIUnitTest.Drupal7.1.inc':
+				return [
+					9  => 2,
+				];
+
+			default:
+				return [];
+		}
+	}
+}

--- a/Security/Tests/BadFunctions/EasyRFIUnitTest.php
+++ b/Security/Tests/BadFunctions/EasyRFIUnitTest.php
@@ -29,6 +29,7 @@ class EasyRFIUnitTest extends AbstractSecurityTestCase
 				return [
 					8  => 1,
 					10 => 1,
+					20 => 1,
 				];
 
 			case 'EasyRFIUnitTest.1.inc':
@@ -36,6 +37,7 @@ class EasyRFIUnitTest extends AbstractSecurityTestCase
 					8  => 1,
 					10 => 1,
 					17 => 1,
+					20 => 1,
 				];
 
 			case 'EasyRFIUnitTest.Drupal7.1.inc':


### PR DESCRIPTION
Related to #57, follow up on #70, this PR adds unit tests for the `Security.BadFunctions.EasyRFI` sniff.

This includes a review of the sniff and making various fixes to it to:
1. Fix various false positives and false negatives.
2. Make the sniff more efficient (faster).
3. Make optimal use of PHPCS.

# Commit Summary

## BadFunctions/EasyRFI: add unit tests

## BadFunctions/EasyRFI: efficiency fix

As the tokens to search for don't change during a PHPCS run, it is inefficient to use the "expensive" `array_merge()` function 1) within a `while` loop and 2) every time the sniff is triggered by an include/require token.

The set of tokens to search for can just as easily be set only once before the sniff is ever triggered and doing so will make the sniff faster.

## BadFunctions/EasyRFI: use the build-in PHPCS functionality [1]

The PHPCS [`addError()`](https://pear.php.net/package/PHP_CodeSniffer/docs/3.5.4/apidoc/PHP_CodeSniffer/File.html#methodaddError) and [`addWarning()`](https://pear.php.net/package/PHP_CodeSniffer/docs/3.5.4/apidoc/PHP_CodeSniffer/File.html#methodaddWarning) functions have a build-in string replacement `sprintf()`-like functionality, so let's use it.

## BadFunctions/EasyRFI: use the build-in PHPCS functionality [2]

The PHPCS native `PHP_CodeSniffer\Util\Tokens` class contains a number of useful token groups.

For this particular sniff, the `Tokens::$includeTokens` applies and contains all the relevant tokens.

It is generally a good idea to use the build-in token groups, as when something would change in how PHP and/or PHPCS tokenizes certain constructs, those groups will be updated too.

## BadFunctions/EasyRFI: bug fix - fix detecting of start/end of the statement [1]

Prevent false negatives when an `include`/`require` statement combines parentheses with concatenation outside parentheses.

Checking whether the next non-empty token is an open parenthesis could cause false negatives as there may be additional parts of the path _after_ the parenthesized part of the statement.

The only reason why this wasn't a problem up to now is because of a bug in the sniff determining `$s`.

The `findNext()` function searches in the token stack and treats the `$start` parameter as _inclusive_.

That means that when searching for the next non-empty token, passing the `$stackPtr` to an include/require statement would _always_ return the `$stackPtr` and not the next non-empty token _after_ the `$stackPtr` which could have been an open parenthesis (or not).

Taking the logic related to the parentheses out of the sniff prevents this issue.

## BadFunctions/EasyRFI: bug fix - fix detecting of start/end of the statement [2]

PHPCS can be run from within an IDE during live coding. Similarly PHPCS can be run over files containing parse errors.

With that in mind, it is best practice to bow out in those cases.
Parse error detection should catch those errors. That is not the responsibility of this sniff.

## BadFunctions/EasyRFI: bug fix - fix detecting of start/end of the statement [3]

An `include`/`require` statement can be used within template files to include another template and doesn't need a closing semi-colon in that case.

That situation was so far not being considered by the sniff and the sniff could in that case search way too far and report on completely unrelated statements after the include.

## BadFunctions/EasyRFI: minor code simplification [1]

Putting the `findNext()` in the `while` condition allows to simplify the `if` conditions within the loop.

## BadFunctions/EasyRFI: minor code simplification [2]

The only token which can have a `content` of `.` is the `T_STRING_CONCAT` token, so we may as well exclude it from being found.

