### PR TITLE
BadFunctions/NoEvals: add unit tests + minor fix

### DIFF
--- a/Security/Sniffs/BadFunctions/NoEvalsSniff.php
+++ b/Security/Sniffs/BadFunctions/NoEvalsSniff.php
@@ -27,7 +27,7 @@ class NoEvalsSniff implements Sniff {
 	*/
 	public function process(File $phpcsFile, $stackPtr) {
 		$tokens = $phpcsFile->getTokens();
-		$error = 'Please do not use eval() functions';
+		$error = 'Please do not use eval()';
 		$phpcsFile->addError($error, $stackPtr, 'NoEvals');
 	}
 

--- a/Security/Sniffs/BadFunctions/NoEvalsSniff.php
+++ b/Security/Sniffs/BadFunctions/NoEvalsSniff.php
@@ -26,7 +26,6 @@ class NoEvalsSniff implements Sniff {
 	* @return void
 	*/
 	public function process(File $phpcsFile, $stackPtr) {
-		$tokens = $phpcsFile->getTokens();
 		$error = 'Please do not use eval()';
 		$phpcsFile->addError($error, $stackPtr, 'NoEvals');
 	}

--- a/Security/Tests/BadFunctions/NoEvalsUnitTest.inc
+++ b/Security/Tests/BadFunctions/NoEvalsUnitTest.inc
@@ -1,0 +1,5 @@
+<?php
+
+eval('$var = file_get_contents(\'filename.php\');');
+eval($string);
+eval("\$var = file_get_contents($filename);');

--- a/Security/Tests/BadFunctions/NoEvalsUnitTest.php
+++ b/Security/Tests/BadFunctions/NoEvalsUnitTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace PHPCS_SecurityAudit\Security\Tests\BadFunctions;
+
+use PHPCS_SecurityAudit\Security\Tests\AbstractSecurityTestCase;
+
+/**
+ * Unit test class for the NoEvals sniff.
+ *
+ * @covers \PHPCS_SecurityAudit\Security\Sniffs\BadFunctions\NoEvalsSniff
+ */
+class NoEvalsUnitTest extends AbstractSecurityTestCase
+{
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getErrorList()
+	{
+		return [
+			3 => 1,
+			4 => 1,
+			5 => 1,
+		];
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getWarningList()
+	{
+		return [];
+	}
+}


### PR DESCRIPTION
Related to #57, follow up on #70, this PR adds unit tests for the `Security.BadFunctions.NoEvals` sniff.

# Commit Summary

## BadFunctions/NoEvals: add unit tests

## BadFunctions/NoEvals: error message precision

`eval()` is a language construct, not a function.

Ref: https://www.php.net/manual/en/function.eval.php

## BadFunctions/NoEvals: remove redundant function call

`$tokens` is not used, so no need to declare it.


