### PR TITLE
BadFunctions/Backticks: add `@covers` tag to the test

### DIFF
--- a/Security/Tests/BadFunctions/BackticksUnitTest.php
+++ b/Security/Tests/BadFunctions/BackticksUnitTest.php
@@ -1,12 +1,14 @@
 <?php
-/**
- * Unit test class for the Backticks sniff.
- */
 
 namespace PHPCS_SecurityAudit\Security\Tests\BadFunctions;
 
 use PHPCS_SecurityAudit\Security\Tests\AbstractSecurityTestCase;
 
+/**
+ * Unit test class for the Backticks sniff.
+ *
+ * @covers \PHPCS_SecurityAudit\Security\Sniffs\BadFunctions\BackticksSniff
+ */
 class BackticksUnitTest extends AbstractSecurityTestCase
 {
 


### PR DESCRIPTION
... and move the docblock to the class so code coverage will actually be recorded.