### PR TITLE
Misc/TypeJuggle: add unit tests + minor fix

### DIFF
--- a/Security/Sniffs/Misc/TypeJuggleSniff.php
+++ b/Security/Sniffs/Misc/TypeJuggleSniff.php
@@ -26,10 +26,10 @@ class TypeJuggleSniff implements Sniff {
 	* @return void
 	*/
 	public function process(File $phpcsFile, $stackPtr) {
-		$tokens = $phpcsFile->getTokens();
 		if (\PHP_CodeSniffer\Config::getConfigData('ParanoiaMode')) {
-			$warning = 'You are using the comparison operator "'. $tokens[$stackPtr]['content'] .'" that converts type and may cause unintended results.';
-			$phpcsFile->addWarning($warning, $stackPtr, 'TypeJuggle');
+			$tokens  = $phpcsFile->getTokens();
+			$warning = 'You are using the comparison operator "%s" that converts type and may cause unintended results.';
+			$phpcsFile->addWarning($warning, $stackPtr, 'TypeJuggle', array($tokens[$stackPtr]['content']));
 		}
 	}
 

--- a/Security/Tests/Misc/TypeJuggleUnitTest.1.inc
+++ b/Security/Tests/Misc/TypeJuggleUnitTest.1.inc
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * Paranoia mode = 1
+ */
+
+// Test for 'equals' conditionals.
+if ( true == $true ) { // Warning.
+	echo 'True';
+} elseif ( false === $true ) {
+	echo 'False';
+}
+
+// Test for 'not equals' conditionals.
+if ( true != $true ) { // Warning.
+	echo 'True';
+} elseif ( true <> $true ) { // Warning.
+	echo 'False';
+} elseif ( false !== $true ) { // Ok.
+	echo 'False';
+}

--- a/Security/Tests/Misc/TypeJuggleUnitTest.inc
+++ b/Security/Tests/Misc/TypeJuggleUnitTest.inc
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * Paranoia mode = 0.
+ */
+
+if ( true == $true ) {
+	echo 'True';
+} elseif ( true != $true ) {
+	echo 'True';
+} elseif ( true <> $true ) {
+	echo 'False';
+}

--- a/Security/Tests/Misc/TypeJuggleUnitTest.php
+++ b/Security/Tests/Misc/TypeJuggleUnitTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace PHPCS_SecurityAudit\Security\Tests\Misc;
+
+use PHPCS_SecurityAudit\Security\Tests\AbstractSecurityTestCase;
+
+/**
+ * Unit test class for the TypeJuggle sniff.
+ *
+ * @covers \PHPCS_SecurityAudit\Security\Sniffs\Misc\TypeJuggleSniff
+ */
+class TypeJuggleUnitTest extends AbstractSecurityTestCase
+{
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getErrorList()
+	{
+		return [];
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getWarningList($testFile = '')
+	{
+		switch ($testFile) {
+			case 'TypeJuggleUnitTest.1.inc':
+				return [
+					8  => 1,
+					15 => 1,
+					17 => 1,
+				];
+
+			default:
+				return [];
+		}
+	}
+}


### PR DESCRIPTION
Related to #57, follow up on #70, this PR adds unit tests for the `Security.Misc.TypeJuggle` sniff.

# Commit Summary

## Misc/TypeJuggle: add unit tests

## Misc/TypeJuggle: use the build-in PHPCS functionality

The PHPCS [`addError()`](https://pear.php.net/package/PHP_CodeSniffer/docs/3.5.4/apidoc/PHP_CodeSniffer/File.html#methodaddError) and [`addWarning()`](https://pear.php.net/package/PHP_CodeSniffer/docs/3.5.4/apidoc/PHP_CodeSniffer/File.html#methodaddWarning) functions have a build-in string replacement `sprintf()`-like functionality, so let's use it.

