### PR TITLE
Composer: update PHPCS Composer plugin dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4",
         "squizlabs/php_codesniffer": "^3.1.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7"
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0"
     },
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4",
         "squizlabs/php_codesniffer": "^3.1.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6"
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7"
     },
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.0",


### PR DESCRIPTION
The DealerDirect Composer plugin has just released version `0.7.0`.
This new version includes support for Composer 2.0.0 (upcoming) and allows for installation of the plugin in combination with PHP 8 and PHPCS 4.x-dev (for testing).

As Composer treats minors < 1.0 as majors, updating to this version requires an update to the `composer.json` requirements.

> For pre-1.0 versions it also acts with safety in mind and treats `^0.3` as `>=0.3.0 <0.4.0`.

Refs:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.7.0
* https://getcomposer.org/doc/articles/versions.md#caret-version-range-